### PR TITLE
INTERLOK-3193 Workflow Activity now keeps a failed message count.

### DIFF
--- a/src/test/java/com/adaptris/monitor/agent/activity/ActivityMapTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/activity/ActivityMapTest.java
@@ -113,6 +113,51 @@ public class ActivityMapTest {
   }
 
   @Test
+  public void testWorkflowFailedMessages() {
+    MessageProcessStep workflowStepOne = new MessageProcessStep();
+    workflowStepOne.setMessageId("1");
+    workflowStepOne.setStepInstanceId("workflow1");
+    workflowStepOne.setStepType(StepType.WORKFLOW);
+    workflowStepOne.setTimeStarted(System.currentTimeMillis());
+    workflowStepOne.setTimeStartedNanos(System.nanoTime());
+    workflowStepOne.setTimeTakenMs(1);
+    workflowStepOne.setTimeTakenNanos(1000);
+    workflowStepOne.setOrder(0);
+    workflowStepOne.setFailed(true);
+    
+    MessageProcessStep workflowStepTwo = new MessageProcessStep();
+    workflowStepTwo.setMessageId("2");
+    workflowStepTwo.setStepInstanceId("workflow1");
+    workflowStepTwo.setStepType(StepType.WORKFLOW);
+    workflowStepTwo.setTimeStarted(System.currentTimeMillis());
+    workflowStepTwo.setTimeStartedNanos(System.nanoTime());
+    workflowStepTwo.setTimeTakenMs(1);
+    workflowStepTwo.setTimeTakenNanos(1000);
+    workflowStepTwo.setOrder(0);
+    workflowStepTwo.setFailed(false);
+    
+    MessageProcessStep workflowStepThree = new MessageProcessStep();
+    workflowStepThree.setMessageId("3");
+    workflowStepThree.setStepInstanceId("workflow1");
+    workflowStepThree.setStepType(StepType.WORKFLOW);
+    workflowStepThree.setTimeStarted(System.currentTimeMillis());
+    workflowStepThree.setTimeStartedNanos(System.nanoTime());
+    workflowStepThree.setTimeTakenMs(1);
+    workflowStepThree.setTimeTakenNanos(1000);
+    workflowStepThree.setOrder(0);
+    workflowStepThree.setFailed(true);
+
+    activityMap.addActivity(workflowStepOne);
+    activityMap.addActivity(workflowStepTwo);
+    activityMap.addActivity(workflowStepThree);
+    
+    WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
+        .get("channel1").getWorkflows().get("workflow1");
+    
+    assertEquals(2, workflowActivity.getFailedCount());
+  }
+  
+  @Test
   public void testProcessEventsWrongConsumerAndProducerProcessStepId() {
     WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
         .get("channel1").getWorkflows().get("workflow1");


### PR DESCRIPTION
*This PR relies on the profiler PR being pushed through, so may fail initially.*

## Motivation

Currently our profiler can report on volume of messages and component performance, but we now want to be able to add failed messages and performance stats for entire workflows.  The profiler has been updated to record this information, the monitor has now been aligned with the profiler to populate our ActivityMap with the failed count and additional workflow stats.

## Modification

Quite Simply, modified the WorkflowActivity so that when it processes profiler events it will pull out and keep a count of the number of failed messages.  This same class noww extends the BaseActivity class to alloww it to have message counts and performance stats too.
Have also modified the WorkflowActivity to output the failed message count/stats in the toString().

## Result

This monitor project publishes an 'ActivityMap' to JMX which holds message counts and performance info for all components.  The ActivityMap will now additionally hold message counts and stats for entire workflows with a failed message count.

## Testing

Should you wish to launch an instance up with the profiler and monitor agent running (see any of our profiler guides for instructions) you'll now see the monitor-agent logging all of the workflow message count/stats/failed messages.
