### PR TITLE
Interlok 3408

### DIFF
--- a/src/main/java/com/adaptris/monitor/agent/AbstractEventPropagator.java
+++ b/src/main/java/com/adaptris/monitor/agent/AbstractEventPropagator.java
@@ -40,12 +40,13 @@ public abstract class AbstractEventPropagator implements EventPropagator {
         try {
           // create a map of the events we have seen, then send the map.
           ActivityMap activityMap = eventMonitorReciever.getAdapterActivityMap();
-          activityMap.resetActivity();
+          ActivityMap clonedActivityMap = (ActivityMap) activityMap.clone();
+          clonedActivityMap.resetActivity();
           for(ProcessStep step : events) {
-            activityMap.addActivity(step);
+            clonedActivityMap.addActivity(step);
           }
 
-          propagateProcessEvent(activityMap);
+          propagateProcessEvent(clonedActivityMap);
         } catch (Throwable t) {
           t.printStackTrace();
         }

--- a/src/main/java/com/adaptris/monitor/agent/activity/ActivityMap.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/ActivityMap.java
@@ -47,4 +47,22 @@ public class ActivityMap implements Serializable {
     return buffer.toString();
   }
 
+  public Object clone() {
+    ActivityMap cloned = new ActivityMap();
+    
+    // read up on clone()
+    // copy the adapters map into the cloned map.
+    
+    // object references
+    // Does Java pass arguments as reference or value?
+    
+    this.getAdapters().forEach( (id, adapterActivity ) -> {
+      BaseActivity clonedBaseActivity = (BaseActivity) ((AdapterActivity) adapterActivity).clone();
+      cloned.getAdapters().put(id, clonedBaseActivity);
+    });
+   
+    ;
+    
+    return cloned;
+  }
 }

--- a/src/main/java/com/adaptris/monitor/agent/activity/ActivityMap.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/ActivityMap.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import com.adaptris.profiler.ProcessStep;
 import com.google.gson.annotations.Expose;
 
-public class ActivityMap implements Serializable {
+public class ActivityMap implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 2523877428476982945L;
 
@@ -50,18 +50,10 @@ public class ActivityMap implements Serializable {
   public Object clone() {
     ActivityMap cloned = new ActivityMap();
     
-    // read up on clone()
-    // copy the adapters map into the cloned map.
-    
-    // object references
-    // Does Java pass arguments as reference or value?
-    
     this.getAdapters().forEach( (id, adapterActivity ) -> {
       BaseActivity clonedBaseActivity = (BaseActivity) ((AdapterActivity) adapterActivity).clone();
       cloned.getAdapters().put(id, clonedBaseActivity);
     });
-   
-    ;
     
     return cloned;
   }

--- a/src/main/java/com/adaptris/monitor/agent/activity/AdapterActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/AdapterActivity.java
@@ -57,4 +57,15 @@ public class AdapterActivity extends BaseActivity implements Serializable {
     return buffer.toString();
   }
 
+  public Object clone() {
+    AdapterActivity cloned = new AdapterActivity();
+    getChannels().forEach( (id, channel) -> {
+      ChannelActivity clonedChannel = (ChannelActivity) channel.clone();
+      cloned.getChannels().put(id, clonedChannel);
+    });
+    
+    cloned.setUniqueId(getUniqueId());
+    
+    return cloned;
+  }
 }

--- a/src/main/java/com/adaptris/monitor/agent/activity/AdapterActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/AdapterActivity.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import com.adaptris.profiler.ProcessStep;
 import com.google.gson.annotations.Expose;
 
-public class AdapterActivity extends BaseActivity implements Serializable {
+public class AdapterActivity extends BaseActivity implements Serializable, Cloneable {
 
   private static final long serialVersionUID = -4031508025636325352L;
 

--- a/src/main/java/com/adaptris/monitor/agent/activity/ChannelActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/ChannelActivity.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import com.adaptris.profiler.ProcessStep;
 import com.google.gson.annotations.Expose;
 
-public class ChannelActivity extends BaseActivity implements Serializable {
+public class ChannelActivity extends BaseActivity implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 1922768482203698311L;
 

--- a/src/main/java/com/adaptris/monitor/agent/activity/ChannelActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/ChannelActivity.java
@@ -57,4 +57,15 @@ public class ChannelActivity extends BaseActivity implements Serializable {
     return buffer.toString();
   }
 
+  public Object clone() {
+    ChannelActivity cloned = new ChannelActivity();
+    getWorkflows().forEach( (id, workflow) -> {
+      WorkflowActivity clonedworkflow = (WorkflowActivity) workflow.clone();
+      cloned.getWorkflows().put(id, clonedworkflow);
+    });
+    
+    cloned.setUniqueId(getUniqueId());
+    
+    return cloned;
+  }
 }

--- a/src/main/java/com/adaptris/monitor/agent/activity/ConsumerActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/ConsumerActivity.java
@@ -34,5 +34,14 @@ public class ConsumerActivity extends BaseFlowActivity implements Serializable {
 
     return buffer.toString();
   }
+  
+  public Object clone() {
+    ConsumerActivity cloned = new ConsumerActivity();
+    
+    cloned.setUniqueId(getUniqueId());
+    cloned.setClassName(getClassName());
+    
+    return cloned;
+  }
 
 }

--- a/src/main/java/com/adaptris/monitor/agent/activity/ProducerActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/ProducerActivity.java
@@ -34,5 +34,14 @@ public class ProducerActivity extends BaseFlowActivity implements Serializable {
 
     return buffer.toString();
   }
+  
+  public Object clone() {
+    ProducerActivity cloned = new ProducerActivity();
+    
+    cloned.setUniqueId(getUniqueId());
+    cloned.setClassName(getClassName());
+    
+    return cloned;
+  }
 
 }

--- a/src/main/java/com/adaptris/monitor/agent/activity/ServiceActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/ServiceActivity.java
@@ -90,5 +90,18 @@ public class ServiceActivity extends BaseFlowActivity implements Serializable {
 
     return buffer.toString();
   }
+  
+  public Object clone() {
+    ServiceActivity cloned = new ServiceActivity();
+    getServices().forEach( (id, service) -> {
+      ServiceActivity clonedService = (ServiceActivity) service.clone();
+      cloned.getServices().put(id, clonedService);
+    });
+    
+    cloned.setUniqueId(getUniqueId());
+    cloned.setClassName(getClassName());
+    
+    return cloned;
+  }
 
 }

--- a/src/main/java/com/adaptris/monitor/agent/activity/ServiceActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/ServiceActivity.java
@@ -9,7 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.adaptris.profiler.ProcessStep;
 import com.google.gson.annotations.Expose;
 
-public class ServiceActivity extends BaseFlowActivity implements Serializable {
+public class ServiceActivity extends BaseFlowActivity implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 5440965750057494954L;
 

--- a/src/main/java/com/adaptris/monitor/agent/activity/WorkflowActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/WorkflowActivity.java
@@ -10,7 +10,7 @@ import com.adaptris.profiler.ProcessStep;
 import com.adaptris.profiler.StepType;
 import com.google.gson.annotations.Expose;
 
-public class WorkflowActivity extends BaseFlowActivity implements Serializable {
+public class WorkflowActivity extends BaseFlowActivity implements Serializable, Cloneable {
 
   private static final long serialVersionUID = -1630350826201321890L;
 

--- a/src/main/java/com/adaptris/monitor/agent/activity/WorkflowActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/WorkflowActivity.java
@@ -124,5 +124,24 @@ public class WorkflowActivity extends BaseFlowActivity implements Serializable {
 
     return buffer.toString();
   }
+  
+  public Object clone() {
+    WorkflowActivity cloned = new WorkflowActivity();
+    getServices().forEach( (id, service) -> {
+      ServiceActivity clonedService = (ServiceActivity) service.clone();
+      cloned.getServices().put(id, clonedService);
+    });
+    
+    ProducerActivity clonedProducer = (ProducerActivity) this.getProducerActivity().clone();
+    ConsumerActivity clonedConumser = (ConsumerActivity) this.getConsumerActivity().clone();
+    
+    cloned.setProducerActivity(clonedProducer);
+    cloned.setConsumerActivity(clonedConumser);
+    
+    cloned.setUniqueId(getUniqueId());
+    cloned.setClassName(getClassName());
+    
+    return cloned;
+  }
 
 }

--- a/src/test/java/com/adaptris/monitor/agent/activity/ActivityMapTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/activity/ActivityMapTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.monitor.agent.activity;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
@@ -124,7 +125,7 @@ public class ActivityMapTest {
     workflowStepOne.setTimeTakenNanos(1000);
     workflowStepOne.setOrder(0);
     workflowStepOne.setFailed(true);
-    
+
     MessageProcessStep workflowStepTwo = new MessageProcessStep();
     workflowStepTwo.setMessageId("2");
     workflowStepTwo.setStepInstanceId("workflow1");
@@ -135,7 +136,7 @@ public class ActivityMapTest {
     workflowStepTwo.setTimeTakenNanos(1000);
     workflowStepTwo.setOrder(0);
     workflowStepTwo.setFailed(false);
-    
+
     MessageProcessStep workflowStepThree = new MessageProcessStep();
     workflowStepThree.setMessageId("3");
     workflowStepThree.setStepInstanceId("workflow1");
@@ -150,13 +151,13 @@ public class ActivityMapTest {
     activityMap.addActivity(workflowStepOne);
     activityMap.addActivity(workflowStepTwo);
     activityMap.addActivity(workflowStepThree);
-    
+
     WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
         .get("channel1").getWorkflows().get("workflow1");
-    
+
     assertEquals(2, workflowActivity.getFailedCount());
   }
-  
+
   @Test
   public void testProcessEventsWrongConsumerAndProducerProcessStepId() {
     WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
@@ -198,7 +199,7 @@ public class ActivityMapTest {
     assertTrue(mapString.contains("consumer"));
     assertTrue(mapString.contains("producer"));
   }
-  
+
   // INTERLOK-3135
   @Test
   public void testConsumerAddedToCorrectWorkflow() throws Exception {
@@ -229,6 +230,23 @@ public class ActivityMapTest {
 
     assertEquals(0, workflowActivity.getConsumerActivity().getMessageCount());
     assertEquals(0, workflowActivity.getProducerActivity().getMessageCount());
+  }
+
+  @Test
+  public void testClone() {
+    
+    ActivityMap activityMapClone = (ActivityMap) activityMap.clone();
+
+
+    assertEquals(activityMap.toString(), activityMapClone.toString());
+    
+    Adapter adapter = TestUtils.buildNestedServiceTestAdapter();
+    adapter.setUniqueId("cloneAdapter");
+    AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
+    
+    
+    activityMapClone = activityMapCreator.createBaseMap(adapter); 
+    assertNotEquals(activityMap.toString(), activityMapClone.toString());
   }
 
 }


### PR DESCRIPTION
## Motivation

Why am I doing this

Every 5 seconds or so interlok-monitor-agent combines all received events into an ActivityMap and produces that map to JMX.
The monitor-agent is currently reusing the same map everytime, therefore overwriting all references to that map.
It should be creating a new map every invocation and publishing to JMX.
A clone needs to be created of the map and the stats set to the ones from the previous 5 seconds.

## Modification

What did I change

Implemented Cloneable and added a clone method to; ActivityMap, AdapterActivity, ChannelActivity, WorkflowActivity, ServiceActivity, ConsumerActivity and ProducerActivity.

A unit test has subsequently been added to cover the new clone method.

## Result

What's the end result for the user

The activity map is no longer overriding it's own map and instead elegantly flowing between the clone and original ActivityMaps

## Testing

How can I test this if I'm reviewing this.

Go to https://interlok.adaptris.net/interlok-docs/advanced-profiler-prometheus.html follow the guide and build a working prometheus profiler. Build the current version of the required projects and drop the jars into the adapter lib directory.
Start the adapter and ApacheJmeter and drop some messages in the statistics should not be identical and the map should update correctly.

Run the tests in interlok-monitor-agent, they should all pass