### PR TITLE
Interlok 3412

### DIFF
--- a/src/main/java/com/adaptris/monitor/agent/activity/AdapterInstanceActivityMapCreator.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/AdapterInstanceActivityMapCreator.java
@@ -3,7 +3,6 @@ package com.adaptris.monitor.agent.activity;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
-import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -25,6 +24,8 @@ import com.adaptris.core.Service;
 import com.adaptris.core.ServiceCollection;
 import com.adaptris.core.Workflow;
 import com.adaptris.core.WorkflowImp;
+import com.adaptris.core.services.conditional.ElseService;
+import com.adaptris.core.services.conditional.ThenService;
 
 public class AdapterInstanceActivityMapCreator implements ActivityMapCreator {
 
@@ -139,6 +140,12 @@ public class AdapterInstanceActivityMapCreator implements ActivityMapCreator {
           if (value != null) {
             if (value instanceof Service) {
               map.add((Service) value);
+            }
+            else if (value instanceof ThenService) {
+              map.add((Service) ((ThenService) value).getService());
+            }
+            else if (value instanceof ElseService) {
+              map.add((Service) ((ElseService) value).getService());
             }
             else if (value instanceof Collection<?>) { // attempt to catch all collection with Service generic type.
               Type methodReturnType = pd.getReadMethod().getGenericReturnType();

--- a/src/main/java/com/adaptris/monitor/agent/activity/ServiceActivity.java
+++ b/src/main/java/com/adaptris/monitor/agent/activity/ServiceActivity.java
@@ -10,7 +10,7 @@ import com.adaptris.profiler.ProcessStep;
 import com.google.gson.annotations.Expose;
 
 public class ServiceActivity extends BaseFlowActivity implements Serializable, Cloneable {
-
+  
   private static final long serialVersionUID = 5440965750057494954L;
 
   @Expose
@@ -30,9 +30,7 @@ public class ServiceActivity extends BaseFlowActivity implements Serializable, C
       setOrder(processStep.getOrder());
     } else {
       for(String serviceId : getServices().keySet()) {
-        if(processStep.getStepInstanceId().equals(serviceId)) {
-          getServices().get(serviceId).addActivity(processStep);
-        }
+        getServices().get(serviceId).addActivity(processStep);
       }
     }
   }

--- a/src/test/java/com/adaptris/monitor/agent/activity/AdapterInstanceActivityMapCreatorTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/activity/AdapterInstanceActivityMapCreatorTest.java
@@ -13,6 +13,9 @@ import com.adaptris.core.Adapter;
 import com.adaptris.core.Service;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.services.LogMessageService;
+import com.adaptris.core.services.conditional.ElseService;
+import com.adaptris.core.services.conditional.IfElse;
+import com.adaptris.core.services.conditional.ThenService;
 import com.adaptris.core.services.metadata.AddMetadataService;
 
 public class AdapterInstanceActivityMapCreatorTest {
@@ -69,6 +72,7 @@ public class AdapterInstanceActivityMapCreatorTest {
     assertEquals(0, serviceActivityList2.getServices().size());
   }
 
+  @Test
   public void testCreateBaseMapWrongObject() {
     Adapter adapter = TestUtils.buildNestedServiceTestAdapter();
 
@@ -81,6 +85,7 @@ public class AdapterInstanceActivityMapCreatorTest {
     }
   }
 
+  @Test
   public void testScanClassReflectiveAllGetters() {
     AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
     AddMetadataService service = new AddMetadataService();
@@ -91,7 +96,33 @@ public class AdapterInstanceActivityMapCreatorTest {
     List<Service> services = activityMapCreator.scanClassReflectiveAllGetters(serviceList);
     assertEquals(1, services.size());
   }
+  
+  @Test
+  public void testScanClassReflectiveAllGettersConditionalServices() {
+    AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
+    
+    LogMessageService logService = new LogMessageService();
+    
+    AddMetadataService addMetaService = new AddMetadataService();
+    addMetaService.addMetadataElement("myKey1", "myValue1");
+    addMetaService.addMetadataElement("myKey2", "myValue2");
+    
+    IfElse service = new IfElse();
+    
+    ThenService thenService = new ThenService();
+    thenService.setService(addMetaService);
+    
+    ElseService elseService = new ElseService();
+    elseService.setService(logService);
+    
+    service.setThen(thenService);
+    service.setOtherwise(elseService);
+    
+    List<Service> services = activityMapCreator.scanClassReflectiveAllGetters(service);
+    assertEquals(2, services.size());
+  }
 
+  @Test
   public void testscanclassreflectiveallgettersthatcausedclasscastexception() {
     AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
     DummyWithPlainCollectionService wrapperService = new DummyWithPlainCollectionService();


### PR DESCRIPTION
## Motivation

Recent tests show that we didn't handle nested services inside our conditional services, instead they were just skipped and therefore not profiled.

## Modification

Very simple change to add specific instanceof checks for ThenService and ElseService when we scan a service for child services.

## Result

You'll now see metrics produced for nested services inside conditionals.

## Testing

You'll need to run with the profiler with the JMX propagator.  Then have an adapter with conditional services actively processing messages.  In the logs every 5 seconds or so you'll see TRACE level metrics being printed which will now include the nested services inside conditionals.
