### PR TITLE
INTERLOK-3555 #comment Update the pom url to point to the right doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 ## Usage
 
-https://interlok.adaptris.net/interlok-docs/developer-profiler.html
+[https://interlok.adaptris.net/interlok-docs/#/pages/developer/developer-profiler](https://interlok.adaptris.net/interlok-docs/#/pages/developer/developer-profiler)

--- a/build.gradle
+++ b/build.gradle
@@ -216,7 +216,7 @@ publishing {
 
       pom.withXml {
         asNode().appendNode("description", "Expose profiling data via Multicast and JMX from the Interlok-Profiler.")
-        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/developer-profiler.html")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/developer/developer-profiler")
         asNode().appendNode("name", componentName)
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.9.0+")


### PR DESCRIPTION
## Motivation
The documentation was broken since we changed the doc site

## Modification
Fix the doc url

## Result
The pom has a correct doc url

## Testing
Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.