### PR TITLE
INTERLOK-3587 Expiring Metrics

### DIFF
--- a/src/main/java/com/adaptris/monitor/agent/EventPropagator.java
+++ b/src/main/java/com/adaptris/monitor/agent/EventPropagator.java
@@ -1,10 +1,11 @@
 package com.adaptris.monitor.agent;
 
+import com.adaptris.core.CoreException;
 import com.adaptris.monitor.agent.activity.ActivityMap;
 
 public interface EventPropagator extends Runnable {
   
-  public void propagateProcessEvent(ActivityMap activityMap);
+  public void propagateProcessEvent(ActivityMap activityMap) throws CoreException;
   
   public void startPropagator();
   

--- a/src/main/java/com/adaptris/monitor/agent/jmx/JmxEventPropagator.java
+++ b/src/main/java/com/adaptris/monitor/agent/jmx/JmxEventPropagator.java
@@ -6,6 +6,7 @@ import javax.management.MBeanRegistrationException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 
+import com.adaptris.core.CoreException;
 import com.adaptris.core.runtime.AdapterComponentMBean;
 import com.adaptris.core.util.JmxHelper;
 import com.adaptris.monitor.agent.AbstractEventPropagator;
@@ -30,13 +31,13 @@ public class JmxEventPropagator extends AbstractEventPropagator {
   }
 
   @Override
-  public void propagateProcessEvent(ActivityMap activityMap) {
+  public void propagateProcessEvent(ActivityMap activityMap) throws CoreException {
     log.debug(activityMap.toString());
 
     sendJmx(activityMap);
   }
 
-  private void sendJmx(ActivityMap activityMap) {
+  private void sendJmx(ActivityMap activityMap) throws CoreException {
     this.eventMBean.addEventActivityMap(activityMap);
   }
 

--- a/src/main/java/com/adaptris/monitor/agent/jmx/ProfilerEventClientMBean.java
+++ b/src/main/java/com/adaptris/monitor/agent/jmx/ProfilerEventClientMBean.java
@@ -1,13 +1,16 @@
 package com.adaptris.monitor.agent.jmx;
 
+import java.util.List;
+
+import com.adaptris.core.CoreException;
 import com.adaptris.monitor.agent.activity.ActivityMap;
 
 public interface ProfilerEventClientMBean {
 
-  public void addEventActivityMap(ActivityMap activityMap);
+  public void addEventActivityMap(ActivityMap activityMap) throws CoreException;
   
-  public ActivityMap getEventActivityMap();
+  public List<ActivityMap> getEventActivityMaps() throws CoreException;
   
-  public int getEventCount();
+  public int getEventCount() throws CoreException;
   
 }

--- a/src/test/java/com/adaptris/monitor/agent/InterlokMonitorPluginFactoryTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/InterlokMonitorPluginFactoryTest.java
@@ -2,31 +2,12 @@ package com.adaptris.monitor.agent;
 
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Before;
 import org.junit.Test;
 
-import com.adaptris.profiler.client.ClientPlugin;
-
 public class InterlokMonitorPluginFactoryTest {
-  
-  private InterlokMonitorPluginFactory factory;
-  
-  @Before
-  public void setUp() throws Exception {
-    factory = new InterlokMonitorPluginFactory();
-  }
-  
-  @Test
-  public void testCreate() throws Exception {
-    assertTrue(factory.getPlugin() instanceof ClientPlugin);
-  }
-  
-  @Test
-  public void testCreateOnlyOnce() throws Exception {
-    ClientPlugin clientPlugin = factory.getPlugin();
-    ClientPlugin clientPlugin2 = factory.getPlugin();
-    
-    assertTrue(clientPlugin == clientPlugin2);
-  }
-
+    @Test
+    public void testGetPlugin() {
+        assertTrue((new InterlokMonitorPluginFactory()).getPlugin() instanceof InterlokMonitorProfilerPlugin);
+    }
 }
+

--- a/src/test/java/com/adaptris/monitor/agent/InterlokMonitorPluginFactoryTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/InterlokMonitorPluginFactoryTest.java
@@ -2,12 +2,35 @@ package com.adaptris.monitor.agent;
 
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
 import org.junit.Test;
 
-public class InterlokMonitorPluginFactoryTest {
-    @Test
-    public void testGetPlugin() {
-        assertTrue((new InterlokMonitorPluginFactory()).getPlugin() instanceof InterlokMonitorProfilerPlugin);
-    }
-}
+import com.adaptris.profiler.client.ClientPlugin;
 
+public class InterlokMonitorPluginFactoryTest {
+
+  private InterlokMonitorPluginFactory factory;
+
+  @Before
+  public void setUp() throws Exception {
+    factory = new InterlokMonitorPluginFactory();
+  }
+
+  @Test
+  public void testCreate() throws Exception {
+    assertTrue(factory.getPlugin() instanceof ClientPlugin);
+  }
+
+  @Test
+  public void testCreateOnlyOnce() throws Exception {
+    ClientPlugin clientPlugin = factory.getPlugin();
+    ClientPlugin clientPlugin2 = factory.getPlugin();
+
+    assertTrue(clientPlugin == clientPlugin2);
+  }
+
+  @Test
+  public void testGetPlugin() {
+    assertTrue((new InterlokMonitorPluginFactory()).getPlugin() instanceof InterlokMonitorProfilerPlugin);
+  }
+}

--- a/src/test/java/com/adaptris/monitor/agent/InterlokMonitorProfilerPluginTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/InterlokMonitorProfilerPluginTest.java
@@ -1,15 +1,92 @@
 package com.adaptris.monitor.agent;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import com.adaptris.profiler.client.EventReceiver;
 
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import com.adaptris.core.Adapter;
+import com.adaptris.core.Channel;
+import com.adaptris.core.StandardWorkflow;
+import com.adaptris.core.services.LogMessageService;
+import com.adaptris.monitor.agent.activity.ActivityMap;
+import com.adaptris.monitor.agent.activity.BaseActivity;
+import com.adaptris.profiler.client.EventReceiver;
+
 public class InterlokMonitorProfilerPluginTest {
+  private static final String ADAPTER_ID = "adapter";
+
+  private InterlokMonitorProfilerPlugin plugin;
+
+  private Adapter adapter;
+
+  @Before
+  public void setUp() throws Exception {
+    plugin = new InterlokMonitorProfilerPlugin();
+    adapter = this.buildTestAdapter();
+  }
+
+  @Test
+  public void testLifecycle() throws Exception {
+    plugin.init(adapter);
+    plugin.start(adapter);
+
+    ActivityMap activityMap = EventMonitorReceiver.getInstance().getAdapterActivityMap();
+    BaseActivity baseActivity = activityMap.getAdapters().get(ADAPTER_ID);
+
+    assertEquals(ADAPTER_ID, baseActivity.getUniqueId());
+
+    plugin.stop(adapter);
+    plugin.close(adapter);
+  }
+
+  @Test
+  public void testLifecycleNoAdapter() throws Exception {
+    plugin.init(new Object());
+    plugin.start(new Object());
+
+    ActivityMap activityMap = EventMonitorReceiver.getInstance().getAdapterActivityMap();
+
+    assertNull(activityMap);
+
+    plugin.stop(new Object());
+    plugin.close(new Object());
+  }
+
+  @Test
+  public void testReceiversInitialised() throws Exception {
+    plugin.init(adapter);
+    plugin.start(adapter);
+
+    EventReceiver eventReceiver = plugin.getReceivers().get(0);
+
+    assertTrue(eventReceiver instanceof EventMonitorReceiver);
+
+    plugin.stop(adapter);
+    plugin.close(adapter);
+  }
+
+  private Adapter buildTestAdapter() {
+    Adapter adapter = new Adapter();
+    adapter.setUniqueId(ADAPTER_ID);
+    Channel channel = new Channel();
+    channel.setUniqueId("channel1");
+    StandardWorkflow workflow = new StandardWorkflow();
+    workflow.setUniqueId("workflow1");
+    LogMessageService service = new LogMessageService();
+    service.setUniqueId("service1");
+
+    workflow.getServiceCollection().add(service);
+    channel.getWorkflowList().add(workflow);
+    adapter.getChannelList().add(channel);
+
+    return adapter;
+  }
+  
     @Test
     public void testConstructor() {
         List<EventReceiver> receivers = (new InterlokMonitorProfilerPlugin()).getReceivers();

--- a/src/test/java/com/adaptris/monitor/agent/InterlokMonitorProfilerPluginTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/InterlokMonitorProfilerPluginTest.java
@@ -1,89 +1,25 @@
 package com.adaptris.monitor.agent;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import com.adaptris.core.Adapter;
-import com.adaptris.core.Channel;
-import com.adaptris.core.StandardWorkflow;
-import com.adaptris.core.services.LogMessageService;
-import com.adaptris.monitor.agent.activity.ActivityMap;
-import com.adaptris.monitor.agent.activity.BaseActivity;
 import com.adaptris.profiler.client.EventReceiver;
 
-public class InterlokMonitorProfilerPluginTest {
-  
-  private static final String ADAPTER_ID = "adapter";
-  
-  private InterlokMonitorProfilerPlugin plugin;
-  
-  private Adapter adapter;
-  
-  @Before
-  public void setUp() throws Exception {
-    plugin = new InterlokMonitorProfilerPlugin();
-    adapter = this.buildTestAdapter();
-  }
-  
-  @Test
-  public void testLifecycle() throws Exception {
-    plugin.init(adapter);
-    plugin.start(adapter);
-    
-    ActivityMap activityMap = EventMonitorReceiver.getInstance().getAdapterActivityMap();
-    BaseActivity baseActivity = activityMap.getAdapters().get(ADAPTER_ID);
-    
-    assertEquals(ADAPTER_ID, baseActivity.getUniqueId());
-    
-    plugin.stop(adapter);
-    plugin.close(adapter);
-  }
-  
-  @Test
-  public void testLifecycleNoAdapter() throws Exception {
-    plugin.init(new Object());
-    plugin.start(new Object());
-    
-    ActivityMap activityMap = EventMonitorReceiver.getInstance().getAdapterActivityMap();
-    
-    assertNull(activityMap);
-    
-    plugin.stop(new Object());
-    plugin.close(new Object());
-  }
-  
-  @Test
-  public void testReceiversInitialised() throws Exception {
-    plugin.init(adapter);
-    plugin.start(adapter);
-    
-    EventReceiver eventReceiver = plugin.getReceivers().get(0);
-    
-    assertTrue(eventReceiver instanceof EventMonitorReceiver);
-    
-    plugin.stop(adapter);
-    plugin.close(adapter);
-  }
-  
-  private Adapter buildTestAdapter() {
-    Adapter adapter = new Adapter();
-    adapter.setUniqueId(ADAPTER_ID);
-    Channel channel = new Channel();
-    channel.setUniqueId("channel1");
-    StandardWorkflow workflow = new StandardWorkflow();
-    workflow.setUniqueId("workflow1");
-    LogMessageService service = new LogMessageService();
-    service.setUniqueId("service1");
-    
-    workflow.getServiceCollection().add(service);
-    channel.getWorkflowList().add(workflow);
-    adapter.getChannelList().add(channel);
-    
-    return adapter;
-  }
+import java.util.List;
 
+import org.junit.Test;
+
+public class InterlokMonitorProfilerPluginTest {
+    @Test
+    public void testConstructor() {
+        List<EventReceiver> receivers = (new InterlokMonitorProfilerPlugin()).getReceivers();
+        assertTrue(receivers instanceof java.util.ArrayList);
+        assertEquals(1, receivers.size());
+    }
+
+    @Test
+    public void testGetReceivers() {
+        assertEquals(1, (new InterlokMonitorProfilerPlugin()).getReceivers().size());
+    }
 }
+

--- a/src/test/java/com/adaptris/monitor/agent/UDPPollerTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/UDPPollerTest.java
@@ -1,0 +1,22 @@
+package com.adaptris.monitor.agent;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class UDPPollerTest {
+    @Test
+    public void testConstructor() {
+        assertTrue((new UDPPoller()).getDatagramReceiver() instanceof UDPDatagramReceiverImpl);
+    }
+
+    @Test
+    public void testSetDatagramReceiver() {
+        UDPPoller udpPoller = new UDPPoller();
+        UDPDatagramReceiverImpl udpDatagramReceiverImpl = new UDPDatagramReceiverImpl();
+        udpPoller.setDatagramReceiver(udpDatagramReceiverImpl);
+        assertSame(udpDatagramReceiverImpl, udpPoller.getDatagramReceiver());
+    }
+}
+

--- a/src/test/java/com/adaptris/monitor/agent/activity/ActivityMapTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/activity/ActivityMapTest.java
@@ -1,12 +1,255 @@
 package com.adaptris.monitor.agent.activity;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import com.adaptris.core.Adapter;
+import com.adaptris.profiler.MessageProcessStep;
+import com.adaptris.profiler.StepType;
+
 public class ActivityMapTest {
+  
+  private ActivityMap activityMap;
+
+  @Before
+  public void setUp() throws Exception {
+    Adapter adapter = TestUtils.buildNestedServiceTestAdapter();
+
+    AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
+    activityMap = activityMapCreator.createBaseMap(adapter);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    activityMap.resetActivity();
+  }
+
+  @Test
+  public void testProcessEvents() {
+    MessageProcessStep serviceListStep = new MessageProcessStep();
+    serviceListStep.setMessageId("1");
+    serviceListStep.setStepInstanceId("serviceList1");
+    serviceListStep.setStepType(StepType.SERVICE);
+    serviceListStep.setTimeStarted(System.currentTimeMillis());
+    serviceListStep.setTimeStartedNanos(System.nanoTime());
+    serviceListStep.setTimeTakenMs(1);
+    serviceListStep.setTimeTakenNanos(1000);
+    serviceListStep.setOrder(0);
+
+    activityMap.addActivity(serviceListStep);
+
+    MessageProcessStep serviceStep = new MessageProcessStep();
+    serviceStep.setMessageId("1");
+    serviceStep.setStepInstanceId("service2");
+    serviceStep.setStepType(StepType.SERVICE);
+    serviceStep.setTimeStarted(System.currentTimeMillis());
+    serviceListStep.setTimeStartedNanos(System.nanoTime());
+    serviceStep.setTimeTakenMs(1);
+    serviceListStep.setTimeTakenNanos(1000);
+    serviceStep.setOrder(1);
+
+    activityMap.addActivity(serviceStep);
+
+    MessageProcessStep consumerStep = new MessageProcessStep();
+    consumerStep.setMessageId("1");
+    consumerStep.setStepInstanceId("consumer");
+    consumerStep.setStepType(StepType.CONSUMER);
+    consumerStep.setTimeStarted(System.currentTimeMillis());
+    consumerStep.setTimeStartedNanos(System.nanoTime());
+    consumerStep.setTimeTakenMs(1);
+    consumerStep.setTimeTakenNanos(1000);
+
+    activityMap.addActivity(consumerStep);
+
+    MessageProcessStep producerStep = new MessageProcessStep();
+    producerStep.setMessageId("1");
+    producerStep.setStepInstanceId("producer");
+    producerStep.setStepType(StepType.PRODUCER);
+    producerStep.setTimeStarted(System.currentTimeMillis());
+    producerStep.setTimeStartedNanos(System.nanoTime());
+    producerStep.setTimeTakenMs(0);
+    producerStep.setTimeTakenNanos(0);
+
+    activityMap.addActivity(producerStep);
+
+    WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
+        .get("channel1").getWorkflows().get("workflow1");
+
+    ConsumerActivity consumerActivity = workflowActivity.getConsumerActivity();
+    ProducerActivity producerActivity = workflowActivity.getProducerActivity();
+
+    ServiceActivity serviceActivity1 = workflowActivity.getServices().get("service1");
+
+    ServiceActivity serviceListActivity1 = workflowActivity.getServices().get("serviceList1");
+    ServiceActivity serviceActivity2 = serviceListActivity1.getServices().get("service2");
+
+    assertEquals(1, consumerActivity.getMessageCount());
+    assertEquals(1, producerActivity.getMessageCount());
+
+    assertEquals(0, serviceActivity1.getMessageCount());
+    assertEquals(-1, serviceActivity1.getOrder());
+
+    assertEquals(1, serviceListActivity1.getMessageCount());
+    assertEquals(0, serviceListActivity1.getOrder());
+    assertEquals(1, serviceActivity2.getMessageCount());
+    assertEquals(1, serviceActivity2.getOrder());
+
+    String mapString = activityMap.toString();
+
+    assertTrue(mapString.contains(TestUtils.ADAPTER_ID));
+    assertTrue(mapString.contains("channel1"));
+    assertTrue(mapString.contains("workflow1"));
+    assertTrue(mapString.contains("service1"));
+    assertTrue(mapString.contains("serviceList1"));
+    assertTrue(mapString.contains("service2"));
+    assertTrue(mapString.contains("serviceList2"));
+    assertTrue(mapString.contains("consumer"));
+    assertTrue(mapString.contains("producer"));
+  }
+
+  @Test
+  public void testWorkflowFailedMessages() {
+    MessageProcessStep workflowStepOne = new MessageProcessStep();
+    workflowStepOne.setMessageId("1");
+    workflowStepOne.setStepInstanceId("workflow1");
+    workflowStepOne.setStepType(StepType.WORKFLOW);
+    workflowStepOne.setTimeStarted(System.currentTimeMillis());
+    workflowStepOne.setTimeStartedNanos(System.nanoTime());
+    workflowStepOne.setTimeTakenMs(1);
+    workflowStepOne.setTimeTakenNanos(1000);
+    workflowStepOne.setOrder(0);
+    workflowStepOne.setFailed(true);
+
+    MessageProcessStep workflowStepTwo = new MessageProcessStep();
+    workflowStepTwo.setMessageId("2");
+    workflowStepTwo.setStepInstanceId("workflow1");
+    workflowStepTwo.setStepType(StepType.WORKFLOW);
+    workflowStepTwo.setTimeStarted(System.currentTimeMillis());
+    workflowStepTwo.setTimeStartedNanos(System.nanoTime());
+    workflowStepTwo.setTimeTakenMs(1);
+    workflowStepTwo.setTimeTakenNanos(1000);
+    workflowStepTwo.setOrder(0);
+    workflowStepTwo.setFailed(false);
+
+    MessageProcessStep workflowStepThree = new MessageProcessStep();
+    workflowStepThree.setMessageId("3");
+    workflowStepThree.setStepInstanceId("workflow1");
+    workflowStepThree.setStepType(StepType.WORKFLOW);
+    workflowStepThree.setTimeStarted(System.currentTimeMillis());
+    workflowStepThree.setTimeStartedNanos(System.nanoTime());
+    workflowStepThree.setTimeTakenMs(1);
+    workflowStepThree.setTimeTakenNanos(1000);
+    workflowStepThree.setOrder(0);
+    workflowStepThree.setFailed(true);
+
+    activityMap.addActivity(workflowStepOne);
+    activityMap.addActivity(workflowStepTwo);
+    activityMap.addActivity(workflowStepThree);
+
+    WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
+        .get("channel1").getWorkflows().get("workflow1");
+
+    assertEquals(2, workflowActivity.getFailedCount());
+  }
+
+  @Test
+  public void testProcessEventsWrongConsumerAndProducerProcessStepId() {
+    WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
+        .get("channel1").getWorkflows().get("workflow1");
+
+    ConsumerActivity consumerActivity = workflowActivity.getConsumerActivity();
+    ProducerActivity producerActivity = workflowActivity.getProducerActivity();
+
+    MessageProcessStep consumerStep = new MessageProcessStep();
+    consumerStep.setMessageId("1");
+    consumerStep.setStepInstanceId("differentId");
+    consumerStep.setStepType(StepType.CONSUMER);
+    consumerStep.setTimeStarted(System.currentTimeMillis());
+    consumerStep.setTimeStartedNanos(System.nanoTime());
+    consumerStep.setTimeTakenMs(1);
+    consumerStep.setTimeTakenNanos(1000);
+
+    consumerActivity.addActivity(consumerStep);
+
+    MessageProcessStep producerStep = new MessageProcessStep();
+    producerStep.setMessageId("1");
+    producerStep.setStepInstanceId("differentId");
+    producerStep.setStepType(StepType.PRODUCER);
+    producerStep.setTimeStarted(System.currentTimeMillis());
+    producerStep.setTimeStartedNanos(System.nanoTime());
+    producerStep.setTimeTakenMs(0);
+    producerStep.setTimeTakenNanos(0);
+
+    producerActivity.addActivity(producerStep);
+
+    assertEquals(0, consumerActivity.getMessageCount());
+    assertEquals(0, producerActivity.getMessageCount());
+
+    String mapString = activityMap.toString();
+
+    assertTrue(mapString.contains(TestUtils.ADAPTER_ID));
+    assertTrue(mapString.contains("channel1"));
+    assertTrue(mapString.contains("workflow1"));
+    assertTrue(mapString.contains("consumer"));
+    assertTrue(mapString.contains("producer"));
+  }
+
+  // INTERLOK-3135
+  @Test
+  public void testConsumerAddedToCorrectWorkflow() throws Exception {
+    WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
+        .get("channel1").getWorkflows().get("workflow1");
+
+    MessageProcessStep consumerStep = new MessageProcessStep();
+    consumerStep.setMessageId("1");
+    consumerStep.setStepInstanceId("differentId");
+    consumerStep.setStepType(StepType.CONSUMER);
+    consumerStep.setTimeStarted(System.currentTimeMillis());
+    consumerStep.setTimeStartedNanos(System.nanoTime());
+    consumerStep.setTimeTakenMs(1);
+    consumerStep.setTimeTakenNanos(1000);
+
+    workflowActivity.addActivity(consumerStep);
+
+    MessageProcessStep producerStep = new MessageProcessStep();
+    producerStep.setMessageId("1");
+    producerStep.setStepInstanceId("differentId");
+    producerStep.setStepType(StepType.PRODUCER);
+    producerStep.setTimeStarted(System.currentTimeMillis());
+    producerStep.setTimeStartedNanos(System.nanoTime());
+    producerStep.setTimeTakenMs(0);
+    producerStep.setTimeTakenNanos(0);
+
+    workflowActivity.addActivity(producerStep);
+
+    assertEquals(0, workflowActivity.getConsumerActivity().getMessageCount());
+    assertEquals(0, workflowActivity.getProducerActivity().getMessageCount());
+  }
+
+  @Test
+  public void testClone() {
+
+    ActivityMap activityMapClone = (ActivityMap) activityMap.clone();
+
+
+    assertEquals(activityMap.toString(), activityMapClone.toString());
+
+    Adapter adapter = TestUtils.buildNestedServiceTestAdapter();
+    adapter.setUniqueId("cloneAdapter");
+    AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
+
+
+    activityMapClone = activityMapCreator.createBaseMap(adapter); 
+    assertNotEquals(activityMap.toString(), activityMapClone.toString());
+  }
+  
     @Test
     public void testConstructor() {
         assertEquals("", (new ActivityMap()).toString());
@@ -31,11 +274,6 @@ public class ActivityMapTest {
         ActivityMap activityMap = new ActivityMap();
         activityMap.setAdapters(stringBaseActivityMap);
         assertEquals("Adapter = null\n", activityMap.toString());
-    }
-
-    @Test
-    public void testClone() {
-        assertEquals("", (new ActivityMap()).clone().toString());
     }
 
     @Test

--- a/src/test/java/com/adaptris/monitor/agent/activity/ActivityMapTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/activity/ActivityMapTest.java
@@ -1,252 +1,50 @@
 package com.adaptris.monitor.agent.activity;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
-import org.junit.After;
-import org.junit.Before;
+import java.util.HashMap;
+
 import org.junit.Test;
 
-import com.adaptris.core.Adapter;
-import com.adaptris.profiler.MessageProcessStep;
-import com.adaptris.profiler.StepType;
-
-
 public class ActivityMapTest {
+    @Test
+    public void testConstructor() {
+        assertEquals("", (new ActivityMap()).toString());
+    }
 
-  private ActivityMap activityMap;
+    @Test
+    public void testSetAdapters() {
+        ActivityMap activityMap = new ActivityMap();
+        activityMap.setAdapters(new HashMap<String, BaseActivity>());
+        assertEquals("", activityMap.toString());
+    }
 
-  @Before
-  public void setUp() throws Exception {
-    Adapter adapter = TestUtils.buildNestedServiceTestAdapter();
+    @Test
+    public void testToString() {
+        assertEquals("", (new ActivityMap()).toString());
+    }
 
-    AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
-    activityMap = activityMapCreator.createBaseMap(adapter);
-  }
+    @Test
+    public void testToString2() {
+        HashMap<String, BaseActivity> stringBaseActivityMap = new HashMap<String, BaseActivity>();
+        stringBaseActivityMap.put("foo", new AdapterActivity());
+        ActivityMap activityMap = new ActivityMap();
+        activityMap.setAdapters(stringBaseActivityMap);
+        assertEquals("Adapter = null\n", activityMap.toString());
+    }
 
-  @After
-  public void tearDown() throws Exception {
-    activityMap.resetActivity();
-  }
+    @Test
+    public void testClone() {
+        assertEquals("", (new ActivityMap()).clone().toString());
+    }
 
-  @Test
-  public void testProcessEvents() {
-    MessageProcessStep serviceListStep = new MessageProcessStep();
-    serviceListStep.setMessageId("1");
-    serviceListStep.setStepInstanceId("serviceList1");
-    serviceListStep.setStepType(StepType.SERVICE);
-    serviceListStep.setTimeStarted(System.currentTimeMillis());
-    serviceListStep.setTimeStartedNanos(System.nanoTime());
-    serviceListStep.setTimeTakenMs(1);
-    serviceListStep.setTimeTakenNanos(1000);
-    serviceListStep.setOrder(0);
-
-    activityMap.addActivity(serviceListStep);
-
-    MessageProcessStep serviceStep = new MessageProcessStep();
-    serviceStep.setMessageId("1");
-    serviceStep.setStepInstanceId("service2");
-    serviceStep.setStepType(StepType.SERVICE);
-    serviceStep.setTimeStarted(System.currentTimeMillis());
-    serviceListStep.setTimeStartedNanos(System.nanoTime());
-    serviceStep.setTimeTakenMs(1);
-    serviceListStep.setTimeTakenNanos(1000);
-    serviceStep.setOrder(1);
-
-    activityMap.addActivity(serviceStep);
-
-    MessageProcessStep consumerStep = new MessageProcessStep();
-    consumerStep.setMessageId("1");
-    consumerStep.setStepInstanceId("consumer");
-    consumerStep.setStepType(StepType.CONSUMER);
-    consumerStep.setTimeStarted(System.currentTimeMillis());
-    consumerStep.setTimeStartedNanos(System.nanoTime());
-    consumerStep.setTimeTakenMs(1);
-    consumerStep.setTimeTakenNanos(1000);
-
-    activityMap.addActivity(consumerStep);
-
-    MessageProcessStep producerStep = new MessageProcessStep();
-    producerStep.setMessageId("1");
-    producerStep.setStepInstanceId("producer");
-    producerStep.setStepType(StepType.PRODUCER);
-    producerStep.setTimeStarted(System.currentTimeMillis());
-    producerStep.setTimeStartedNanos(System.nanoTime());
-    producerStep.setTimeTakenMs(0);
-    producerStep.setTimeTakenNanos(0);
-
-    activityMap.addActivity(producerStep);
-
-    WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
-        .get("channel1").getWorkflows().get("workflow1");
-
-    ConsumerActivity consumerActivity = workflowActivity.getConsumerActivity();
-    ProducerActivity producerActivity = workflowActivity.getProducerActivity();
-
-    ServiceActivity serviceActivity1 = workflowActivity.getServices().get("service1");
-
-    ServiceActivity serviceListActivity1 = workflowActivity.getServices().get("serviceList1");
-    ServiceActivity serviceActivity2 = serviceListActivity1.getServices().get("service2");
-
-    assertEquals(1, consumerActivity.getMessageCount());
-    assertEquals(1, producerActivity.getMessageCount());
-
-    assertEquals(0, serviceActivity1.getMessageCount());
-    assertEquals(-1, serviceActivity1.getOrder());
-
-    assertEquals(1, serviceListActivity1.getMessageCount());
-    assertEquals(0, serviceListActivity1.getOrder());
-    assertEquals(1, serviceActivity2.getMessageCount());
-    assertEquals(1, serviceActivity2.getOrder());
-
-    String mapString = activityMap.toString();
-
-    assertTrue(mapString.contains(TestUtils.ADAPTER_ID));
-    assertTrue(mapString.contains("channel1"));
-    assertTrue(mapString.contains("workflow1"));
-    assertTrue(mapString.contains("service1"));
-    assertTrue(mapString.contains("serviceList1"));
-    assertTrue(mapString.contains("service2"));
-    assertTrue(mapString.contains("serviceList2"));
-    assertTrue(mapString.contains("consumer"));
-    assertTrue(mapString.contains("producer"));
-  }
-
-  @Test
-  public void testWorkflowFailedMessages() {
-    MessageProcessStep workflowStepOne = new MessageProcessStep();
-    workflowStepOne.setMessageId("1");
-    workflowStepOne.setStepInstanceId("workflow1");
-    workflowStepOne.setStepType(StepType.WORKFLOW);
-    workflowStepOne.setTimeStarted(System.currentTimeMillis());
-    workflowStepOne.setTimeStartedNanos(System.nanoTime());
-    workflowStepOne.setTimeTakenMs(1);
-    workflowStepOne.setTimeTakenNanos(1000);
-    workflowStepOne.setOrder(0);
-    workflowStepOne.setFailed(true);
-
-    MessageProcessStep workflowStepTwo = new MessageProcessStep();
-    workflowStepTwo.setMessageId("2");
-    workflowStepTwo.setStepInstanceId("workflow1");
-    workflowStepTwo.setStepType(StepType.WORKFLOW);
-    workflowStepTwo.setTimeStarted(System.currentTimeMillis());
-    workflowStepTwo.setTimeStartedNanos(System.nanoTime());
-    workflowStepTwo.setTimeTakenMs(1);
-    workflowStepTwo.setTimeTakenNanos(1000);
-    workflowStepTwo.setOrder(0);
-    workflowStepTwo.setFailed(false);
-
-    MessageProcessStep workflowStepThree = new MessageProcessStep();
-    workflowStepThree.setMessageId("3");
-    workflowStepThree.setStepInstanceId("workflow1");
-    workflowStepThree.setStepType(StepType.WORKFLOW);
-    workflowStepThree.setTimeStarted(System.currentTimeMillis());
-    workflowStepThree.setTimeStartedNanos(System.nanoTime());
-    workflowStepThree.setTimeTakenMs(1);
-    workflowStepThree.setTimeTakenNanos(1000);
-    workflowStepThree.setOrder(0);
-    workflowStepThree.setFailed(true);
-
-    activityMap.addActivity(workflowStepOne);
-    activityMap.addActivity(workflowStepTwo);
-    activityMap.addActivity(workflowStepThree);
-
-    WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
-        .get("channel1").getWorkflows().get("workflow1");
-
-    assertEquals(2, workflowActivity.getFailedCount());
-  }
-
-  @Test
-  public void testProcessEventsWrongConsumerAndProducerProcessStepId() {
-    WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
-        .get("channel1").getWorkflows().get("workflow1");
-
-    ConsumerActivity consumerActivity = workflowActivity.getConsumerActivity();
-    ProducerActivity producerActivity = workflowActivity.getProducerActivity();
-
-    MessageProcessStep consumerStep = new MessageProcessStep();
-    consumerStep.setMessageId("1");
-    consumerStep.setStepInstanceId("differentId");
-    consumerStep.setStepType(StepType.CONSUMER);
-    consumerStep.setTimeStarted(System.currentTimeMillis());
-    consumerStep.setTimeStartedNanos(System.nanoTime());
-    consumerStep.setTimeTakenMs(1);
-    consumerStep.setTimeTakenNanos(1000);
-
-    consumerActivity.addActivity(consumerStep);
-
-    MessageProcessStep producerStep = new MessageProcessStep();
-    producerStep.setMessageId("1");
-    producerStep.setStepInstanceId("differentId");
-    producerStep.setStepType(StepType.PRODUCER);
-    producerStep.setTimeStarted(System.currentTimeMillis());
-    producerStep.setTimeStartedNanos(System.nanoTime());
-    producerStep.setTimeTakenMs(0);
-    producerStep.setTimeTakenNanos(0);
-
-    producerActivity.addActivity(producerStep);
-
-    assertEquals(0, consumerActivity.getMessageCount());
-    assertEquals(0, producerActivity.getMessageCount());
-
-    String mapString = activityMap.toString();
-
-    assertTrue(mapString.contains(TestUtils.ADAPTER_ID));
-    assertTrue(mapString.contains("channel1"));
-    assertTrue(mapString.contains("workflow1"));
-    assertTrue(mapString.contains("consumer"));
-    assertTrue(mapString.contains("producer"));
-  }
-
-  // INTERLOK-3135
-  @Test
-  public void testConsumerAddedToCorrectWorkflow() throws Exception {
-    WorkflowActivity workflowActivity = ((AdapterActivity) activityMap.getAdapters().get(TestUtils.ADAPTER_ID)).getChannels()
-        .get("channel1").getWorkflows().get("workflow1");
-
-    MessageProcessStep consumerStep = new MessageProcessStep();
-    consumerStep.setMessageId("1");
-    consumerStep.setStepInstanceId("differentId");
-    consumerStep.setStepType(StepType.CONSUMER);
-    consumerStep.setTimeStarted(System.currentTimeMillis());
-    consumerStep.setTimeStartedNanos(System.nanoTime());
-    consumerStep.setTimeTakenMs(1);
-    consumerStep.setTimeTakenNanos(1000);
-
-    workflowActivity.addActivity(consumerStep);
-
-    MessageProcessStep producerStep = new MessageProcessStep();
-    producerStep.setMessageId("1");
-    producerStep.setStepInstanceId("differentId");
-    producerStep.setStepType(StepType.PRODUCER);
-    producerStep.setTimeStarted(System.currentTimeMillis());
-    producerStep.setTimeStartedNanos(System.nanoTime());
-    producerStep.setTimeTakenMs(0);
-    producerStep.setTimeTakenNanos(0);
-
-    workflowActivity.addActivity(producerStep);
-
-    assertEquals(0, workflowActivity.getConsumerActivity().getMessageCount());
-    assertEquals(0, workflowActivity.getProducerActivity().getMessageCount());
-  }
-
-  @Test
-  public void testClone() {
-    
-    ActivityMap activityMapClone = (ActivityMap) activityMap.clone();
-
-
-    assertEquals(activityMap.toString(), activityMapClone.toString());
-    
-    Adapter adapter = TestUtils.buildNestedServiceTestAdapter();
-    adapter.setUniqueId("cloneAdapter");
-    AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
-    
-    
-    activityMapClone = activityMapCreator.createBaseMap(adapter); 
-    assertNotEquals(activityMap.toString(), activityMapClone.toString());
-  }
-
+    @Test
+    public void testClone2() {
+        HashMap<String, BaseActivity> stringBaseActivityMap = new HashMap<String, BaseActivity>();
+        stringBaseActivityMap.put("foo", new AdapterActivity());
+        ActivityMap activityMap = new ActivityMap();
+        activityMap.setAdapters(stringBaseActivityMap);
+        assertEquals("Adapter = null\n", activityMap.clone().toString());
+    }
 }
+

--- a/src/test/java/com/adaptris/monitor/agent/activity/AdapterActivityTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/activity/AdapterActivityTest.java
@@ -1,0 +1,77 @@
+package com.adaptris.monitor.agent.activity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+
+public class AdapterActivityTest {
+    @Test
+    public void testConstructor() {
+        assertEquals("Adapter = null\n", (new AdapterActivity()).toString());
+    }
+
+    @Test
+    public void testAddChannelActivity() {
+        AdapterActivity adapterActivity = new AdapterActivity();
+        adapterActivity.addChannelActivity(new ChannelActivity());
+        assertEquals("Adapter = null\n\tChannel = null\n", adapterActivity.toString());
+    }
+
+    @Test
+    public void testSetChannels() {
+        AdapterActivity adapterActivity = new AdapterActivity();
+        adapterActivity.setChannels(new HashMap<String, ChannelActivity>());
+        assertEquals("Adapter = null\n", adapterActivity.toString());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("Adapter = null\n", (new AdapterActivity()).toString());
+    }
+
+    @Test
+    public void testToString2() {
+        HashMap<String, ChannelActivity> stringChannelActivityMap = new HashMap<String, ChannelActivity>();
+        stringChannelActivityMap.put("foo", new ChannelActivity());
+        AdapterActivity adapterActivity = new AdapterActivity();
+        adapterActivity.setChannels(stringChannelActivityMap);
+        assertEquals("Adapter = null\n\tChannel = null\n", adapterActivity.toString());
+    }
+
+    @Test
+    public void testClone() {
+        Object actualCloneResult = (new AdapterActivity()).clone();
+        String actualUniqueId = ((AdapterActivity) actualCloneResult).getUniqueId();
+        assertEquals("Adapter = null\n", actualCloneResult.toString());
+        assertNull(actualUniqueId);
+    }
+
+    @Test
+    public void testClone2() {
+        HashMap<String, ChannelActivity> stringChannelActivityMap = new HashMap<String, ChannelActivity>();
+        stringChannelActivityMap.put("foo", new ChannelActivity());
+        AdapterActivity adapterActivity = new AdapterActivity();
+        adapterActivity.setChannels(stringChannelActivityMap);
+        Object actualCloneResult = adapterActivity.clone();
+        String actualUniqueId = ((AdapterActivity) actualCloneResult).getUniqueId();
+        assertEquals("Adapter = null\n\tChannel = null\n", actualCloneResult.toString());
+        assertNull(actualUniqueId);
+    }
+
+    @Test
+    public void testClone3() {
+        HashMap<String, ChannelActivity> stringChannelActivityMap = new HashMap<String, ChannelActivity>();
+        stringChannelActivityMap.put("foo", new ChannelActivity());
+        stringChannelActivityMap.put("foo", new ChannelActivity());
+        AdapterActivity adapterActivity = new AdapterActivity();
+        adapterActivity.setChannels(stringChannelActivityMap);
+        Object actualCloneResult = adapterActivity.clone();
+        String actualUniqueId = ((AdapterActivity) actualCloneResult).getUniqueId();
+        assertEquals("Adapter = null\n\tChannel = null\n", actualCloneResult.toString());
+        assertNull(actualUniqueId);
+    }
+}
+

--- a/src/test/java/com/adaptris/monitor/agent/activity/ChannelActivityTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/activity/ChannelActivityTest.java
@@ -1,0 +1,22 @@
+package com.adaptris.monitor.agent.activity;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+
+public class ChannelActivityTest {
+    @Test
+    public void testConstructor() {
+        assertEquals("\tChannel = null\n", (new ChannelActivity()).toString());
+    }
+
+    @Test
+    public void testSetWorkflows() {
+        ChannelActivity channelActivity = new ChannelActivity();
+        channelActivity.setWorkflows(new HashMap<String, WorkflowActivity>());
+        assertEquals("\tChannel = null\n", channelActivity.toString());
+    }
+}
+

--- a/src/test/java/com/adaptris/monitor/agent/activity/ServiceActivityTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/activity/ServiceActivityTest.java
@@ -1,0 +1,15 @@
+package com.adaptris.monitor.agent.activity;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ServiceActivityTest {
+    @Test
+    public void testConstructor() {
+        ServiceActivity actualServiceActivity = new ServiceActivity();
+        assertEquals("\t\t\tService = null (-1) (0 at 0  nanos (0 ms))\n", actualServiceActivity.toString());
+        assertEquals(-1L, actualServiceActivity.getOrder());
+    }
+}
+

--- a/src/test/java/com/adaptris/monitor/agent/activity/WorkflowActivityTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/activity/WorkflowActivityTest.java
@@ -1,0 +1,87 @@
+package com.adaptris.monitor.agent.activity;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.adaptris.core.Adapter;
+import com.adaptris.profiler.MessageProcessStep;
+import com.adaptris.profiler.StepType;
+
+public class WorkflowActivityTest {
+  @Test
+  public void testConstructor() {
+    assertEquals("\t\tWorkflow = null (0 ( failed (0 ) at 0  nanos (0 ms))\nnullnull",
+        (new WorkflowActivity()).toString());
+  }
+
+  @Test
+  public void testAddActivity() {
+    Adapter adapter = TestUtils.buildNestedServiceTestAdapter();
+
+    AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
+    ActivityMap activityMap = activityMapCreator.createBaseMap(adapter);
+    
+    MessageProcessStep step = new MessageProcessStep();
+    step.setStepInstanceId("service1");
+    step.setStepType(StepType.SERVICE);
+    step.setStepName("serviceList2");
+    step.setTimeTakenNanos(100);
+    
+    activityMap.addActivity(step);
+    
+    assertEquals(100, (((AdapterActivity) activityMap.getAdapters()
+        .get(TestUtils.ADAPTER_ID)).getChannels()
+        .get("channel1").getWorkflows()
+        .get("workflow1").getServices()
+        .get("service1").getAvgNsTaken()));
+  }
+  
+  @Test
+  public void testResetActivity() {
+    Adapter adapter = TestUtils.buildNestedServiceTestAdapter();
+
+    AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
+    ActivityMap activityMap = activityMapCreator.createBaseMap(adapter);
+    
+    MessageProcessStep step = new MessageProcessStep();
+    step.setStepInstanceId("service1");
+    step.setStepType(StepType.SERVICE);
+    step.setStepName("serviceList2");
+    step.setTimeTakenNanos(100);
+    
+    activityMap.addActivity(step);
+    
+    activityMap.resetActivity();
+    
+    assertEquals(0, (((AdapterActivity) activityMap.getAdapters()
+        .get(TestUtils.ADAPTER_ID)).getChannels()
+        .get("channel1").getWorkflows()
+        .get("workflow1").getServices()
+        .get("service1").getAvgNsTaken()));
+  }
+  
+  @Test
+  public void testCloneActivity() {
+    Adapter adapter = TestUtils.buildNestedServiceTestAdapter();
+
+    AdapterInstanceActivityMapCreator activityMapCreator = new AdapterInstanceActivityMapCreator();
+    ActivityMap activityMap = activityMapCreator.createBaseMap(adapter);
+    
+    MessageProcessStep step = new MessageProcessStep();
+    step.setStepInstanceId("service1");
+    step.setStepType(StepType.SERVICE);
+    step.setStepName("serviceList2");
+    step.setTimeTakenNanos(100);
+    
+    activityMap.addActivity(step);
+    
+    ActivityMap clone = (ActivityMap) activityMap.clone();
+    
+    assertEquals(0, (((AdapterActivity) clone.getAdapters()
+        .get(TestUtils.ADAPTER_ID)).getChannels()
+        .get("channel1").getWorkflows()
+        .get("workflow1").getServices()
+        .get("service1").getAvgNsTaken()));
+  }
+}

--- a/src/test/java/com/adaptris/monitor/agent/jmx/JmxEventPropagatorTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/jmx/JmxEventPropagatorTest.java
@@ -35,7 +35,7 @@ public class JmxEventPropagatorTest {
     propagator.propagateProcessEvent(activityMap);
     
     assertEquals(1, propagator.getEventMBean().getEventCount());
-    assertNotNull(propagator.getEventMBean().getEventActivityMap());
+    assertNotNull(propagator.getEventMBean().getEventActivityMaps());
   }
 
   @Test

--- a/src/test/java/com/adaptris/monitor/agent/jmx/ProfilerEventClientTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/jmx/ProfilerEventClientTest.java
@@ -1,0 +1,56 @@
+package com.adaptris.monitor.agent.jmx;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ProfilerEventClientTest {
+    @Test
+    public void testConstructor() throws Exception {
+        ProfilerEventClient actualProfilerEventClient = new ProfilerEventClient();
+        assertEquals(0, actualProfilerEventClient.getMaxEventHistory());
+        assertEquals(0, actualProfilerEventClient.getEventCount());
+    }
+
+    @Test
+    public void testSetMaxEventHistory() {
+        ProfilerEventClient profilerEventClient = new ProfilerEventClient();
+        profilerEventClient.setMaxEventHistory(3);
+        assertEquals(3, profilerEventClient.getMaxEventHistory());
+    }
+
+    @Test
+    public void testMaxEventHistory() {
+        assertEquals(100, (new ProfilerEventClient()).maxEventHistory());
+    }
+
+    @Test
+    public void testGetEventQueue() throws Exception {
+        ProfilerEventClient profilerEventClient = new ProfilerEventClient();
+        assertEquals(0, profilerEventClient.getEventCache().size());
+        assertEquals(0, profilerEventClient.getEventCount());
+    }
+
+    @Test
+    public void testGetEventQueue2() throws Exception {
+        ProfilerEventClient profilerEventClient = new ProfilerEventClient();
+        profilerEventClient.setMaxEventHistory(3);
+        assertEquals(0, profilerEventClient.getEventCache().size());
+        assertEquals(0, profilerEventClient.getEventCount());
+    }
+
+    @Test
+    public void testGetEventCount() throws Exception {
+        ProfilerEventClient profilerEventClient = new ProfilerEventClient();
+        assertEquals(0, profilerEventClient.getEventCount());
+        assertEquals(0, profilerEventClient.getEventCount());
+    }
+
+    @Test
+    public void testGetEventActivityMap() throws Exception {
+        ProfilerEventClient profilerEventClient = new ProfilerEventClient();
+        assertEquals(0, profilerEventClient.getEventActivityMaps().size());
+        assertEquals(0, profilerEventClient.getEventCount());
+    }
+}
+

--- a/src/test/java/com/adaptris/monitor/agent/json/EventJsonMarshallerTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/json/EventJsonMarshallerTest.java
@@ -1,0 +1,16 @@
+package com.adaptris.monitor.agent.json;
+
+import static org.junit.Assert.assertSame;
+
+import com.adaptris.monitor.agent.activity.ActivityMap;
+import org.junit.Test;
+
+public class EventJsonMarshallerTest {
+    @Test
+    public void testActivtyWrapperConstructor() {
+        EventJsonMarshaller eventJsonMarshaller = new EventJsonMarshaller();
+        ActivityMap activityMap = new ActivityMap();
+//        assertSame((eventJsonMarshaller.new ActivtyWrapper(activityMap)).adapters, activityMap);
+    }
+}
+

--- a/src/test/java/com/adaptris/monitor/agent/multicast/MulticastEventReceiverTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/multicast/MulticastEventReceiverTest.java
@@ -1,15 +1,82 @@
 package com.adaptris.monitor.agent.multicast;
 
+import static org.mockito.Mockito.when;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.monitor.agent.EventReceiverListener;
+import com.adaptris.monitor.agent.activity.ActivityMap;
+import com.adaptris.monitor.agent.activity.AdapterActivity;
 
 public class MulticastEventReceiverTest {
+
+  private static final String DEFAULT_MULTICAST_GROUP = "224.0.0.4";
+  private static final int DEFAULT_MULTICAST_PORT = 5577;
+  private static final int STANDARD_PACKET_SIZE = 120400;
+
+  private MulticastEventReceiver receiver;
+
+  @Mock MulticastSocketReceiver mockReceiver;
+
+  private final Object monitor = new Object();
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+
+    receiver = new MulticastEventReceiver();
+    receiver.setMulticastSocketReceiver(mockReceiver);
+  }
+
+  @Test
+  public void testReceive() throws Exception {    
+    when(mockReceiver.receive(STANDARD_PACKET_SIZE))
+        .thenReturn(buildPacket());
+
+    receiver.addEventReceiverListener(new EventReceiverListener() {
+      
+      @Override
+      public void eventReceived(ActivityMap activityMap) {
+        monitor.notifyAll();
+      }
+    });
+    receiver.start();
+
+    synchronized(monitor) {
+      // Wait at most 10 seconds... since multicast doesn't always work.
+      monitor.wait(TimeUnit.SECONDS.toMillis(10L));
+    }
+    receiver.stop();
+  }
+  
+    
     @Test
     public void testConstructor() {
         MulticastEventReceiver actualMulticastEventReceiver = new MulticastEventReceiver();
         assertTrue(actualMulticastEventReceiver.getMulticastSocketReceiver() instanceof MulticastSocketReceiverImpl);
         assertTrue(actualMulticastEventReceiver.log instanceof org.slf4j.impl.SimpleLogger);
     }
-}
 
+  private DatagramPacket buildPacket() throws Exception {
+    ActivityMap activityMap = new ActivityMap();
+    activityMap.getAdapters().put("adapter", new AdapterActivity());
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+    oos.writeObject(activityMap);
+    oos.flush();
+    byte[] data= baos.toByteArray();
+
+    return new DatagramPacket(data, data.length, InetAddress.getByName(DEFAULT_MULTICAST_GROUP), DEFAULT_MULTICAST_PORT);
+  }
+}

--- a/src/test/java/com/adaptris/monitor/agent/multicast/MulticastEventReceiverTest.java
+++ b/src/test/java/com/adaptris/monitor/agent/multicast/MulticastEventReceiverTest.java
@@ -1,72 +1,15 @@
 package com.adaptris.monitor.agent.multicast;
 
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertTrue;
 
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectOutputStream;
-import java.net.DatagramPacket;
-import java.net.InetAddress;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-import com.adaptris.monitor.agent.EventReceiverListener;
-import com.adaptris.monitor.agent.activity.ActivityMap;
-import com.adaptris.monitor.agent.activity.AdapterActivity;
 
 public class MulticastEventReceiverTest {
-  
-  private static final String DEFAULT_MULTICAST_GROUP = "224.0.0.4";
-  private static final int DEFAULT_MULTICAST_PORT = 5577;
-  private static final int STANDARD_PACKET_SIZE = 120400;
-  
-  private MulticastEventReceiver receiver;
-  
-  @Mock MulticastSocketReceiver mockReceiver;
-  
-  private final Object monitor = new Object();
-    
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    
-    receiver = new MulticastEventReceiver();
-    receiver.setMulticastSocketReceiver(mockReceiver);
-  }
-  
-  @Test
-  public void testReceive() throws Exception {    
-    when(mockReceiver.receive(STANDARD_PACKET_SIZE))
-        .thenReturn(buildPacket());
-    
-    receiver.addEventReceiverListener(new EventReceiverListener() {
-      @Override
-      public void eventReceived(ActivityMap activityMap) {
-          monitor.notifyAll();
-      }
-    });
-    receiver.start();
-        
-    synchronized(monitor) {
-      // Wait at most 10 seconds... since multicast doesn't always work.
-      monitor.wait(TimeUnit.SECONDS.toMillis(10L));
+    @Test
+    public void testConstructor() {
+        MulticastEventReceiver actualMulticastEventReceiver = new MulticastEventReceiver();
+        assertTrue(actualMulticastEventReceiver.getMulticastSocketReceiver() instanceof MulticastSocketReceiverImpl);
+        assertTrue(actualMulticastEventReceiver.log instanceof org.slf4j.impl.SimpleLogger);
     }
-    receiver.stop();
-  }
-  
-  private DatagramPacket buildPacket() throws Exception {
-    ActivityMap activityMap = new ActivityMap();
-    activityMap.getAdapters().put("adapter", new AdapterActivity());
-    
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    ObjectOutputStream oos = new ObjectOutputStream(baos);
-    oos.writeObject(activityMap);
-    oos.flush();
-    byte[] data= baos.toByteArray();
-
-    return new DatagramPacket(data, data.length, InetAddress.getByName(DEFAULT_MULTICAST_GROUP), DEFAULT_MULTICAST_PORT);
-  }
 }
+


### PR DESCRIPTION
## Motivation

Our metrics are currently stored in JMX bean objects.  They are backed by a Queue, which means every time you want to pull a copy of the metrics they are then removed from the queue, meaning further pulls will not return the same metric data.

This doesn't work very well when you have a cluster of prometheus engines all looking to pull data.  Instead we need each prometheus pull from different instances to have the same data.

We need to change the storage structure of the metrics to not use a queue, but we also need them to expire.

## Modification

There are quite a lot of changes here, most of which you won't care about - simply adding unit tests to a project starved of them.

The changes you probably are interested in are to the ProfilerEventClient.  This is the object responsible for storing and retrieving the metric data.  Now we use the Interlok-core ExpiringMapCache. Defaulting to 10 seconds as expiry.  10 seconds matches the collation of metrics by this project.

## Result
We can now point multiple prometheus cluster instances at our metric endpoint knowing that each pull of data will not effect the next pull.

## Testing

You'll need the profiler up and running and then to generate metrics with some adapter activity.
Follow this [guide ](https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-profiler-prometheus)to get the profiler and prometheus endpoint up and running.  The documentation is a little out of date (for now), just make sure you enable the following managementComponents; "metrics-interlok" and "metrics-provider-prometheus".

Then once activity is pumping through your Interlok instance you can fire multiple GET requests to the Interlok prometheus endpoint (http://localhost:8080/prometheus/metrics) and retrieve the same data over and over until the expiry kicks in.
