### PR TITLE
INTERLOK-3723 Debug Vs Trace

### DIFF
--- a/src/main/java/com/adaptris/monitor/agent/AbstractEventPropagator.java
+++ b/src/main/java/com/adaptris/monitor/agent/AbstractEventPropagator.java
@@ -35,7 +35,6 @@ public abstract class AbstractEventPropagator implements EventPropagator {
       }
 
       List<ProcessStep> events = eventMonitorReciever.getEvents();
-      log.debug("Getting process events - " + events.size());
       if(events.size() > 0) {
         try {
           // create a map of the events we have seen, then send the map.

--- a/src/main/java/com/adaptris/monitor/agent/jmx/JmxEventPropagator.java
+++ b/src/main/java/com/adaptris/monitor/agent/jmx/JmxEventPropagator.java
@@ -32,7 +32,7 @@ public class JmxEventPropagator extends AbstractEventPropagator {
 
   @Override
   public void propagateProcessEvent(ActivityMap activityMap) throws CoreException {
-    log.debug(activityMap.toString());
+    log.trace(activityMap.toString());
 
     sendJmx(activityMap);
   }

--- a/src/main/java/com/adaptris/monitor/agent/jmx/ProfilerEventClient.java
+++ b/src/main/java/com/adaptris/monitor/agent/jmx/ProfilerEventClient.java
@@ -41,17 +41,14 @@ public class ProfilerEventClient implements ProfilerEventClientMBean {
   }
   
   public int getEventCount() throws CoreException {
-    log.trace("get count: " + this.getEventCache().size());
     return this.getEventCache().size();
   }
   
   public void addEventActivityMap(ActivityMap activityMap) throws CoreException {
     this.getEventCache().put(Long.toString(System.currentTimeMillis()), activityMap);
-    log.trace("Add: " + this.getEventCount());
   }
   
   public List<ActivityMap> getEventActivityMaps() throws CoreException {
-    log.trace("get map: " + this.getEventCount());
     return this.getEventCache().getKeys().stream().map( key -> {
       try {
         return (ActivityMap) getEventCache().get(key);
@@ -69,7 +66,6 @@ public class ProfilerEventClient implements ProfilerEventClientMBean {
       
       eventCache.init();
     }
-    log.trace("get queue: " + eventCache.size());
     return eventCache;
   }
 


### PR DESCRIPTION
## Motivation

The logging in this project was not very useful and probably at the wrong level.  

## Modification

All trace logging has been removed simply because it provides very little if any benefit.  To make logging more consistent I have also switched the ActivityMap logging output to trace.
